### PR TITLE
Support newer PHP versions

### DIFF
--- a/SongFormat.php
+++ b/SongFormat.php
@@ -1,4 +1,4 @@
-#!/usr/bin/env php5
+#!/usr/bin/env php
 <?php
 
 //// Configuration


### PR DESCRIPTION
PHP 5 is close to its support end.
Since the script runs just fine with e.g. PHP 7 as well, I suggest to just stop explicitly using "php5" to allow using newer PHP versions as well.